### PR TITLE
waffle.io Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,3 @@
+.. image:: https://badge.waffle.io/django-caching-framework/cache-version.png?label=ready&title=Ready 
+ :target: https://waffle.io/django-caching-framework/cache-version
+ :alt: 'Stories in Ready'


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/django-caching-framework/cache-version

This was requested by a real person (user thedrow) on waffle.io, we're not trying to spam you.
